### PR TITLE
Feat: Popup 컴포넌트, Footer 구현

### DIFF
--- a/components/Layout/Footer/Footer.tsx
+++ b/components/Layout/Footer/Footer.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+
+function Footer() {
+  return (
+    <div className="absolute bottom-0 w-full h-[160px] bg-nomad-black flex justify-center">
+      <div className="w-[1200px] flex justify-between py-8 mx-12 m:grid m:grid-cols-2 m:mx-6 m:justify-center">
+        <p className="text-[#676767]">©codeit - 2023</p>
+        <div className="flex gap-8">
+          <p className="text-[#676767]">Privacy Policy</p>
+          <p className="text-[#676767]">FAQ</p>
+        </div>
+        <div className="flex w-[116px] h-[20px] justify-between">
+          <Link href="https://www.facebook.com/" target="_blank">
+            <Image
+              src="/icon/facebook.svg"
+              width={20}
+              height={20}
+              alt="facebook"
+            />
+          </Link>
+          <Link href="https://www.x.com/" target="_blank">
+            <Image
+              src="/icon/twitter.svg"
+              width={20}
+              height={20}
+              alt="twitter"
+            />
+          </Link>
+          <Link href="https://www.youtube.com/" target="_blank">
+            <Image
+              src="/icon/youtube.svg"
+              width={20}
+              height={20}
+              alt="youtube"
+            />
+          </Link>
+          <Link href="https://www.instagram.com/" target="_blank">
+            <Image
+              src="/icon/instagram.svg"
+              width={20}
+              height={20}
+              alt="instagram"
+            />
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Footer;

--- a/components/Popup/Popup.tsx
+++ b/components/Popup/Popup.tsx
@@ -1,0 +1,81 @@
+import { popupState } from '@/states/popupState';
+import React, { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import Image from 'next/image';
+
+function Popup() {
+  const [popup, setPopup] = useRecoilState(popupState);
+
+  const closeModal = () => {
+    setPopup({ ...popup, isOpen: false });
+  };
+
+  const handleCallback = () => {
+    if (popup.callBackFnc) {
+      popup.callBackFnc();
+    }
+    closeModal();
+  };
+
+  useEffect(() => {
+    if (popup.isOpen) {
+      document.body.classList.add('overflow-hidden');
+    } else {
+      document.body.classList.remove('overflow-hidden');
+    }
+
+    return () => {
+      document.body.classList.remove('overflow-hidden');
+    };
+  }, [popup.isOpen]);
+
+  return (
+    popup.isOpen && (
+      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
+        {popup.popupType === 'alert' ? (
+          <div className="bg-white rounded-lg w-[540px] h-[250px] text-lg flex flex-col items-center justify-center p-4 relative m:w-[327px] m:h-[220px] m:text-base">
+            <p className="mb-4 text-center text-nomad-black">{popup.content}</p>
+            <button
+              className="absolute bottom-7 right-7 w-[120px] h-[48px] bg-nomad-black text-white py-2 rounded-lg hover:bg-var-black m:right-auto m:left-1/2 m:transform m:-translate-x-1/2 m:bottom-4 m:text-sm m:w-[138px] m:h-[42px] m:mb-2"
+              onClick={handleCallback}
+            >
+              {popup.btnName[0]}
+            </button>
+          </div>
+        ) : (
+          <div className="bg-white rounded-xl w-[298px] h-[184px] flex flex-col items-center justify-center p-6">
+            <div className="flex justify-center mb-6">
+              <Image
+                src="/icon/popup_check.svg"
+                width={24}
+                height={24}
+                alt="check icon"
+              />
+            </div>
+            <div className="flex flex-col justify-between h-full">
+              <p className="mb-4 text-center text-nomad-black">
+                {popup.content}
+              </p>
+              <div className="flex justify-between gap-2">
+                <button
+                  className="w-[80px] h-[38px] bg-white text-nomad-black font-bold text-sm py-2 rounded-md border border-nomad-black hover:bg-var-gray3"
+                  onClick={closeModal}
+                >
+                  {popup.btnName[0]}
+                </button>
+                <button
+                  className="w-[80px] h-[38px] bg-nomad-black text-white font-bold text-sm py-2 rounded-md hover:bg-var-black"
+                  onClick={handleCallback}
+                >
+                  {popup.btnName[1]}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    )
+  );
+}
+
+export default Popup;

--- a/components/Popup/Popup.tsx
+++ b/components/Popup/Popup.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 function Popup() {
   const [popup, setPopup] = useRecoilState(popupState);
 
-  const closeModal = () => {
+  const closePopup = () => {
     setPopup({ ...popup, isOpen: false });
   };
 
@@ -14,7 +14,7 @@ function Popup() {
     if (popup.callBackFnc) {
       popup.callBackFnc();
     }
-    closeModal();
+    closePopup();
   };
 
   useEffect(() => {
@@ -59,7 +59,7 @@ function Popup() {
               <div className="flex justify-between gap-2">
                 <button
                   className="w-[80px] h-[38px] bg-white text-nomad-black font-bold text-sm py-2 rounded-md border border-nomad-black hover:bg-var-gray3"
-                  onClick={closeModal}
+                  onClick={closePopup}
                 >
                   {popup.btnName[0]}
                 </button>

--- a/components/Popup/Popup.types.ts
+++ b/components/Popup/Popup.types.ts
@@ -1,0 +1,7 @@
+export interface PopupProps {
+  isOpen: boolean;
+  popupType: '' | 'alert' | 'select';
+  content: string;
+  btnName: [string, string?];
+  callBackFnc?: () => void;
+}

--- a/hooks/usePopup.ts
+++ b/hooks/usePopup.ts
@@ -1,0 +1,23 @@
+import { useRecoilState } from 'recoil';
+import { popupState } from '@/states/popupState';
+import { PopupProps } from '@/components/Popup/Popup.types';
+
+export const usePopup = () => {
+  const [popup, setPopup] = useRecoilState(popupState);
+
+  const openPopup = (props: Omit<PopupProps, 'isOpen'>) => {
+    setPopup({
+      ...props,
+      isOpen: true,
+    });
+  };
+
+  const closePopup = () => {
+    setPopup({
+      ...popup,
+      isOpen: false,
+    });
+  };
+
+  return { openPopup, closePopup };
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
 import { RecoilRoot } from 'recoil';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import Popup from '@/components/Popup/Popup';
 
 const queryClient = new QueryClient();
 
@@ -10,6 +11,7 @@ export default function App({ Component, pageProps }: AppProps) {
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>
         <Component {...pageProps} />
+        <Popup />
       </QueryClientProvider>
     </RecoilRoot>
   );

--- a/pages/popup.tsx
+++ b/pages/popup.tsx
@@ -1,0 +1,37 @@
+import { usePopup } from '@/hooks/usePopup';
+import React from 'react';
+
+const popup = () => {
+  const { openPopup } = usePopup();
+
+  return (
+    <div className="h-[120vh]">
+      <button
+        onClick={() =>
+          openPopup({
+            popupType: 'alert',
+            content: '가입이 완료되었습니다!',
+            btnName: ['확인'],
+            callBackFnc: () => alert('여기에 이벤트 추가하면 됩니다!'),
+          })
+        }
+      >
+        [가입하기]
+      </button>
+      <button
+        onClick={() =>
+          openPopup({
+            popupType: 'select',
+            content: '예약을 취소하시겠어요?',
+            btnName: ['아니오', '취소하기'],
+            callBackFnc: () => alert('여기에 이벤트 추가하면 됩니다!'),
+          })
+        }
+      >
+        [취소하기]
+      </button>
+    </div>
+  );
+};
+
+export default popup;

--- a/public/icon/popup_check.svg
+++ b/public/icon/popup_check.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="12" fill="#112211"/>
+<path d="M7.60742 12.3494L10.6878 15.5003L16.2503 8.35742" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/states/popupState.tsx
+++ b/states/popupState.tsx
@@ -1,0 +1,13 @@
+import { PopupProps } from '@/components/Popup/Popup.types';
+import { atom } from 'recoil';
+
+export const popupState = atom<PopupProps>({
+  key: 'popupState',
+  default: {
+    isOpen: false,
+    popupType: '',
+    content: '',
+    btnName: [''],
+    callBackFnc: undefined,
+  },
+});


### PR DESCRIPTION
### 🔎 작업 내용
 - [x] Popup 컴포넌트 구현

![image](https://github.com/eunji-0623/GlobalNomad/assets/57613101/485f6cf0-362a-433a-baa1-9ebf6c021928)
![image](https://github.com/eunji-0623/GlobalNomad/assets/57613101/1afe1884-ffd6-4b81-ae6f-242dbf081f19)
![image](https://github.com/eunji-0623/GlobalNomad/assets/57613101/7d135cd7-a020-49e3-a881-bd82efcb5a44)

 - [x] Footer 구현
 
![image](https://github.com/eunji-0623/GlobalNomad/assets/57613101/300e63f8-af1b-4ae0-99f0-fdda617bbc54)


### :warning: 이슈
 - 

### :loudspeaker: 전달사항
 - Popup 모달이 열려있는 상태에서는 스크롤을 할 수 없도록 처리하였습니다.
 - pages의 `popup.tsx` 파일은 test용 임시 파일로 추후 삭제 예정입니다.
 - 아래 예시 코드와 같이 버튼의 onClick 이벤트로 추가하여 사용하면 됩니다.
  > 확인 버튼만 있는 팝업 `popupType : alert`
 버튼이 두 개 있는 팝업 `popupType : select`
 ```tsx
import { usePopup } from '@/hooks/usePopup';
import React from 'react';

const popup = () => {
  const { openPopup } = usePopup();

  return (
    <div className="h-[120vh]">
      // 확인 버튼만 있는 팝업 모달
      <button
        onClick={() =>
          openPopup({
            popupType: 'alert',
            content: '가입이 완료되었습니다!',
            btnName: ['확인'],
            callBackFnc: () => alert('여기에 이벤트 추가하면 됩니다!'),
          })
        }
      >
        [가입하기]
      </button>

      // 버튼이 두 개 있는 팝업 모달
      <button
        onClick={() =>
          openPopup({
            popupType: 'select',
            content: '예약을 취소하시겠어요?',
            btnName: ['아니오', '취소하기'],
            callBackFnc: () => alert('여기에 이벤트 추가하면 됩니다!'),
          })
        }
      >
        [취소하기]
      </button>
    </div>
  );
};

export default popup;

 ```
