### PR TITLE
Feat: 로그아웃기능 및 login상태 관리 구현

### DIFF
--- a/hooks/useLogin.ts
+++ b/hooks/useLogin.ts
@@ -5,8 +5,10 @@ import { usePopup } from './usePopup';
 import { LoginBody, LoginResponse } from '@/pages/api/auth/auth.types';
 import { LoginAccess } from '@/pages/api/auth/auth';
 import INSTANCE_URL from '@/pages/api/instance';
+import useLoginState from './useLoginState';
 
 export default function useLogin() {
+  const { setIsLoggedIn } = useLoginState();
   const router = useRouter();
   const { openPopup } = usePopup();
   const postLoginMutation: UseMutationResult<
@@ -42,6 +44,7 @@ export default function useLogin() {
       INSTANCE_URL.defaults.headers.common['Authorization'] =
         `Bearer ${accessToken}`;
 
+      setIsLoggedIn(true);
       localStorage.setItem('refreshToken', refreshToken);
       localStorage.setItem('userId', user.id);
     },

--- a/hooks/useLogin.ts
+++ b/hooks/useLogin.ts
@@ -33,13 +33,6 @@ export default function useLogin() {
       }
     },
     onSuccess: (data) => {
-      openPopup({
-        popupType: 'alert',
-        content: '환영합니다!',
-        btnName: ['확인'],
-        callBackFnc: () => router.push(`/`),
-      });
-
       const { accessToken, refreshToken, user } = data;
       INSTANCE_URL.defaults.headers.common['Authorization'] =
         `Bearer ${accessToken}`;

--- a/hooks/useLoginState.ts
+++ b/hooks/useLoginState.ts
@@ -1,0 +1,8 @@
+import { loginState } from '@/states/loginState';
+import { useRecoilState } from 'recoil';
+
+export default function useLoginState() {
+  const [isLoggedIn, setIsLoggedIn] = useRecoilState(loginState);
+
+  return { isLoggedIn, setIsLoggedIn };
+}

--- a/hooks/useLogout.ts
+++ b/hooks/useLogout.ts
@@ -1,0 +1,13 @@
+import useLoginState from './useLoginState';
+
+export default function useLogout() {
+  const { setIsLoggedIn } = useLoginState();
+
+  const logout = () => {
+    localStorage.removeItem('refreshToken');
+    localStorage.removeItem('userId');
+    setIsLoggedIn(false);
+  };
+
+  return logout;
+}

--- a/hooks/useSilentRefresh.ts
+++ b/hooks/useSilentRefresh.ts
@@ -1,0 +1,22 @@
+import { apiRefreshToken } from '@/pages/api/auth/auth';
+import { useEffect, useState } from 'react';
+import useLoginState from './useLoginState';
+
+export default function SilentRefresh() {
+  const [refreshed, setRefreshed] = useState(false);
+  const { setIsLoggedIn } = useLoginState();
+
+  useEffect(() => {
+    const refreshToken =
+      typeof window !== 'undefined'
+        ? localStorage.getItem('refreshToken')
+        : null;
+    if (refreshToken && !refreshed) {
+      apiRefreshToken(setIsLoggedIn).then(() => setRefreshed(!refreshed));
+    }
+
+    if (!refreshToken) setIsLoggedIn(false);
+  }, [refreshed]);
+
+  return null;
+}

--- a/hooks/useUserData.ts
+++ b/hooks/useUserData.ts
@@ -2,7 +2,7 @@ import { apiMyInfo } from '@/pages/api/users/apiUsers';
 import { userState } from '@/states/userState';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 
 export const useUserData = () => {
   const [userId, setUserId] = useState<string>();

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,10 @@
         "react-calendar": "^5.0.0",
         "react-dom": "^18",
         "react-hook-form": "^7.52.1",
-        "recoil": "^0.7.7",
-        "tailwind-scrollbar-hide": "^1.1.7"
         "react-slick": "^0.30.2",
         "recoil": "^0.7.7",
-        "slick-carousel": "^1.8.1"
+        "slick-carousel": "^1.8.1",
+        "tailwind-scrollbar-hide": "^1.1.7"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4984,11 +4983,6 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
-    },
-    "node_modules/tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/tailwind-scrollbar-hide": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,10 @@
     "react-calendar": "^5.0.0",
     "react-dom": "^18",
     "react-hook-form": "^7.52.1",
-    "recoil": "^0.7.7",
-    "tailwind-scrollbar-hide": "^1.1.7"
     "react-slick": "^0.30.2",
     "recoil": "^0.7.7",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "tailwind-scrollbar-hide": "^1.1.7"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,15 +6,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Popup from '@/components/Popup/Popup';
 import Layout from '@/components/Layout/Layout';
 import Modal from '@/components/Modal/Modal';
-import { useEffect, useState } from 'react';
-import { apiRefreshToken } from './api/auth/auth';
 import LayoutMobile from '@/components/Layout/LayoutMobile';
+import SilentRefresh from '@/hooks/useSilentRefresh';
 
 const queryClient = new QueryClient();
 
 export default function App({ Component, pageProps }: AppProps) {
   let childContent: React.ReactNode;
-  const [refreshed, setRefreshed] = useState(false);
 
   switch (pageProps.layoutType) {
     case 'removeLayout':
@@ -36,22 +34,13 @@ export default function App({ Component, pageProps }: AppProps) {
       break;
   }
 
-  useEffect(() => {
-    const refreshToken =
-      typeof window !== 'undefined'
-        ? localStorage.getItem('refreshToken')
-        : null;
-    if (refreshToken && !refreshed) {
-      apiRefreshToken().then(() => setRefreshed(!refreshed));
-    }
-  }, [refreshed]);
-
   return (
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>
         {childContent}
         <Popup />
         <Modal />
+        <SilentRefresh />
       </QueryClientProvider>
     </RecoilRoot>
   );

--- a/pages/api/auth/auth.ts
+++ b/pages/api/auth/auth.ts
@@ -1,3 +1,4 @@
+import { SetterOrUpdater } from 'recoil';
 import INSTANCE_URL from '../instance';
 import { LoginBody, LoginResponse } from './auth.types';
 
@@ -8,7 +9,9 @@ export const LoginAccess = async (body: LoginBody): Promise<LoginResponse> => {
   return response.data;
 };
 
-export const apiRefreshToken = async () => {
+export const apiRefreshToken = async (
+  setIsLoggedIn: SetterOrUpdater<boolean>
+): Promise<LoginResponse | void> => {
   const currentrefreshToken = localStorage.getItem('refreshToken');
   INSTANCE_URL.defaults.headers.common['Authorization'] =
     `Bearer ${currentrefreshToken}`;
@@ -21,6 +24,7 @@ export const apiRefreshToken = async () => {
       `Bearer ${accessToken}`;
 
     localStorage.setItem('refreshToken', refreshToken);
+    setIsLoggedIn(true);
 
     setTimeout(apiRefreshToken, JWT_EXPIRY_TIME - 60000);
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -39,7 +39,7 @@ export default function LoginPage() {
 
   useEffect(() => {
     if (isLoggedIn) router.push('/mypage');
-  });
+  }, [isLoggedIn]);
 
   return (
     <div className="flex flex-col items-center max-w-[640px] m-auto pt-[160px] gap-[40px] px-[20px] ">

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -6,18 +6,15 @@ import { loginValidation } from '@/components/AuthInputBox/validation';
 import Link from 'next/link';
 import { PrimaryButton } from '@/components/Button/Button';
 import useLogin from '@/hooks/useLogin';
-import { useMemo } from 'react';
-
-export const getStaticProps = async () => {
-  return {
-    props: {
-      layoutType: 'removeLayout',
-    },
-  };
-};
+import { useEffect, useMemo } from 'react';
+import useLoginState from '@/hooks/useLoginState';
+import { useRouter } from 'next/router';
+import { GetServerSideProps } from 'next';
 
 export default function LoginPage() {
   const { postLoginMutation } = useLogin();
+  const { isLoggedIn } = useLoginState();
+  const router = useRouter();
   const {
     register,
     handleSubmit,
@@ -39,6 +36,10 @@ export default function LoginPage() {
 
     return isFormFilled && isNotError;
   }, [errors.email, errors.password, watchFields]);
+
+  useEffect(() => {
+    if (isLoggedIn) router.push('/mypage');
+  });
 
   return (
     <div className="flex flex-col items-center max-w-[640px] m-auto pt-[160px] gap-[40px] px-[20px] ">

--- a/pages/logoutTest.tsx
+++ b/pages/logoutTest.tsx
@@ -1,0 +1,15 @@
+import useLoginState from '@/hooks/useLoginState';
+import useLogout from '@/hooks/useLogout';
+
+export default function logoutTest() {
+  const logout = useLogout();
+  const { isLoggedIn } = useLoginState();
+
+  console.log(isLoggedIn);
+
+  return (
+    <div>
+      <button onClick={logout}>로그아웃</button>
+    </div>
+  );
+}

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -7,7 +7,9 @@ import { signUpFormValues } from '@/components/AuthInputBox/AuthInputBox.types';
 import { signupValidation } from '@/components/AuthInputBox/validation';
 import { PrimaryButton } from '@/components/Button/Button';
 import { SignupBody } from './api/users/apiUser.types';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import useLoginState from '@/hooks/useLoginState';
+import { useRouter } from 'next/router';
 
 export const getStaticProps = async () => {
   return {
@@ -19,7 +21,10 @@ export const getStaticProps = async () => {
 
 export default function SingupPage() {
   const [isChecked, setIsChecked] = useState(false);
+  const { isLoggedIn } = useLoginState();
+  const router = useRouter();
   const { postSignupMutation } = useSignup();
+
   const {
     register,
     handleSubmit,
@@ -57,6 +62,12 @@ export default function SingupPage() {
     errors.nickname,
     watchFields,
   ]);
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      router.push('/mypage');
+    }
+  }, [isLoggedIn]);
 
   return (
     <div className="flex flex-col items-center max-w-[640px] m-auto pt-[160px] gap-[40px] px-[20px] ">

--- a/states/loginState.tsx
+++ b/states/loginState.tsx
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const loginState = atom<boolean>({
+  key: 'loginState',
+  default: false,
+});


### PR DESCRIPTION
### 🔎 작업 내용
 - [x] 로그아웃 usehook구현하였습니다.
 - [x] app컴포넌트에 refreshToken구현되었던 부분 컴포넌트로 분리했습니다.
 - [x] 커스텀훅으로 isLoggedIn 변수 사용가능합니다.
 - [x] 자세한 예시는 logoutTest 페이지에서 확인 가능합니다.
 - [x] 로그인, 회원가입 페이지에 로그인상태로 접근시 마이페이지로 리다이렉트

### :warning: 이슈
 - useLogin과 useLoginState이름이 사용하기에 헷갈리실 수 있을 것 같습니다...
 - useRefreshToken 이걸 useHook으로 만드는게 맞는지 모르겠습니다. 컴포넌트 폴더에 넣는게 맞을지 고민됩니다.
 - 로그인, 회원가입 페이지에 로그인상태로 접근시에 페이지가 랜더링되어 화면에 그려진 후에 리다이렉트 됩니다.. next.js로 해결해보려고 했으나 로그인상태, refreshToken 둘 다 next.js에서는 접근이 안돼서 해결이 안될 것 같습니다.. return null로도 랜더링이 안막아지더라구요,, 아이디어 있으시면 공유부탁드립니다..