### PR TITLE
Feat: 후기 작성 구현

### DIFF
--- a/components/Review/Rating.tsx
+++ b/components/Review/Rating.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
+import { RatingProps } from './Review.types';
+
+export default function Rating({ currentRating, onRatingChange }: RatingProps) {
+  const [rating, setRating] = useState(currentRating);
+  const [hoverRating, setHoverRating] = useState<number>(0);
+  const totalStars = 5;
+
+  useEffect(() => {
+    setRating(currentRating);
+  }, [currentRating]);
+
+  const handleMouseEnter = (index: number) => {
+    setHoverRating(index);
+  };
+
+  const handleMouseLeave = () => {
+    setHoverRating(0);
+  };
+
+  const handleClick = (index: number) => {
+    setRating(index);
+    onRatingChange(index);
+  };
+
+  return (
+    <div className="flex gap-1 w-full h-[100px] items-center justify-center">
+      {Array.from({ length: totalStars }, (_, index) => (
+        <Image
+          key={index}
+          src={
+            index < (hoverRating || rating)
+              ? '/icon/icon_star_on.svg'
+              : '/icon/icon_star_off.svg'
+          }
+          width={50}
+          height={50}
+          alt={index < (hoverRating || rating) ? '채워진 별점' : '빈 별점'}
+          onMouseEnter={() => handleMouseEnter(index + 1)}
+          onMouseLeave={handleMouseLeave}
+          onClick={() => handleClick(index + 1)}
+          className="cursor-pointer"
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/Review/Rating.tsx
+++ b/components/Review/Rating.tsx
@@ -4,7 +4,7 @@ import { RatingProps } from './Review.types';
 
 export default function Rating({ currentRating, onRatingChange }: RatingProps) {
   const [rating, setRating] = useState(currentRating);
-  const [hoverRating, setHoverRating] = useState<number>(0);
+  const [hoverRating, setHoverRating] = useState<number>(1);
   const totalStars = 5;
 
   useEffect(() => {

--- a/components/Review/Review.tsx
+++ b/components/Review/Review.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { useModal } from '@/hooks/useModal';
+import Image from 'next/image';
+import { PrimaryButton } from '@/components/Button/Button';
+import { formatCurrency } from '@/utils/formatCurrency';
+import Rating from './Rating';
+import { useMutation } from '@tanstack/react-query';
+import {
+  ReservationId,
+  ReviewBody,
+} from '@/pages/api/myReservations/apiMyReservations.types';
+import { apiReview } from '@/pages/api/myReservations/apiMyReservations';
+
+export default function Review({ reservationId }: ReservationId) {
+  const { openModal } = useModal();
+  const [reviewContent, setReviewContent] = useState<string>('');
+  const [rating, setRating] = useState<number>(0);
+
+  const mutation = useMutation({
+    mutationFn: (data: { id: ReservationId; body: ReviewBody }) =>
+      apiReview(data.id, data.body),
+    onSuccess: (result) => {
+      console.log('후기 작성 완료: ', result);
+    },
+    onError: (error) => {
+      console.error('후기 작성 에러: ', error);
+    },
+  });
+
+  const handleReviewSubmit = async () => {
+    const body: ReviewBody = {
+      rating,
+      content: reviewContent,
+    };
+    mutation.mutate({
+      id: { reservationId },
+      body,
+    });
+  };
+
+  return (
+    <>
+      <PrimaryButton
+        size="small"
+        style="dark"
+        onClick={() =>
+          openModal({
+            title: '후기 작성',
+            hasButton: true,
+            callBackFnc: handleReviewSubmit,
+            buttonChildren: '작성하기',
+            content: (
+              <>
+                <div className="flex gap-6 m:gap-4">
+                  <Image
+                    src="https://i.pinimg.com/236x/11/77/23/117723c9b6841f44f96e348c452bb1da.jpg"
+                    width={125}
+                    height={125}
+                    alt="체험 사진"
+                    className="object-cover rounded-xl m:w-[100px] m:h-[100px]"
+                  />
+                  <div className="text-nomad-black flex flex-col justify-between">
+                    <p className="font-bold text-xl m:text-base max-w-[290px] m:max-w-[220px] overflow-hidden whitespace-nowrap text-ellipsis">
+                      함께 배우면 즐거운 스트릿 댄스
+                    </p>
+                    <div className="flex gap-2 m:text-sm m:gap-1">
+                      <p>2023. 2. 14</p>
+                      <p>·</p>
+                      <p>11:00 - 12:30</p>
+                      <p>·</p>
+                      <p>10명</p>
+                    </div>
+                    <div className="border border-solid border-var-gray2" />
+                    <p className="font-bold text-[32px] m:text-xl">
+                      ₩ {formatCurrency(10000)}
+                    </p>
+                  </div>
+                </div>
+                <Rating
+                  onRatingChange={(rating) => setRating(rating)}
+                  currentRating={rating}
+                />
+                <div className="w-full h-[200px] m:h-1/2 p-4 rounded border border-solid border-var-gray2">
+                  <textarea
+                    className="w-full h-full border-none outline-none text-base resize-none scrollbar-hide"
+                    placeholder="후기를 작성해 주세요."
+                    onChange={(e) => setReviewContent(e.target.value)}
+                  />
+                </div>
+              </>
+            ),
+          })
+        }
+      >
+        후기작성
+      </PrimaryButton>
+    </>
+  );
+}

--- a/components/Review/Review.tsx
+++ b/components/Review/Review.tsx
@@ -14,7 +14,7 @@ import { apiReview } from '@/pages/api/myReservations/apiMyReservations';
 export default function Review({ reservationId }: ReservationId) {
   const { openModal } = useModal();
   const [reviewContent, setReviewContent] = useState<string>('');
-  const [rating, setRating] = useState<number>(0);
+  const [rating, setRating] = useState<number>(1);
 
   const mutation = useMutation({
     mutationFn: (data: { id: ReservationId; body: ReviewBody }) =>

--- a/components/Review/Review.types.ts
+++ b/components/Review/Review.types.ts
@@ -1,0 +1,4 @@
+export interface RatingProps {
+  currentRating: number;
+  onRatingChange: (newRating: number) => void;
+}

--- a/pages/review.tsx
+++ b/pages/review.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import Review from '@/components/Review/Review';
+
+export default function review() {
+  return <Review reservationId={2468} />;
+}


### PR DESCRIPTION
### 🔎 작업 내용
 - [x] 후기 작성

![image](https://github.com/eunji-0623/GlobalNomad/assets/57613101/ebb9c21c-4534-4fae-b59d-9a6180c36253)
![image](https://github.com/eunji-0623/GlobalNomad/assets/57613101/64a1cb5b-ae96-42f1-8721-cf1823df6d39)

### :warning: 이슈
 - 예약 내역 페이지 완성 후 `후기 작성` 버튼 클릭할 때 reservationId 및 Activity data props로 전달받아서 모달 내 사진, 텍스트 변경해야 합니다.

### :loudspeaker: 전달사항
 - `작성하기` 버튼 api 연결해두었습니다. 실험을 해보려고 했으나... [예약->승인->체험 시간이 지난 체험] 이 과정을 거쳐야 리뷰 작성이 가능해서... 추후 수정이 필요할 수도 있습니다.. ㅜㅜ
 - pages/review 추후 삭제 예정
