### PR TITLE
Feat: 예약 내역 페이지 무한스크롤 구현

### DIFF
--- a/hooks/useReservationList.ts
+++ b/hooks/useReservationList.ts
@@ -1,21 +1,45 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { apiMyReservationList } from '@/pages/api/myReservations/apiMyReservations';
 import { useUserData } from './useUserData';
 import { MyReservationListResponse } from '@/pages/api/myReservations/apiMyReservations.types';
+import { useMemo } from 'react';
+
+const INITIAL_SIZE = 4;
+const REFETCH_SIZE = 1;
 
 export const useReservationList = () => {
   const userData = useUserData();
 
-  const { data: myReservationList } = useQuery<MyReservationListResponse>({
-    queryKey: ['myReservationList', userData.id],
-    queryFn: () =>
-      apiMyReservationList({
-        cursorId: undefined,
-        size: undefined,
-        status: undefined,
-      }),
-    enabled: !!userData.id,
-  });
+  const { data, fetchNextPage, hasNextPage, isLoading, isFetchingNextPage } =
+    useInfiniteQuery<MyReservationListResponse>({
+      queryKey: ['myReservationList', userData.id],
+      queryFn: ({ pageParam = undefined }) => {
+        const size = pageParam === undefined ? INITIAL_SIZE : REFETCH_SIZE;
+        return apiMyReservationList({
+          size: size,
+          cursorId: pageParam as number | undefined,
+        });
+      },
+      enabled: !!userData.id,
+      getNextPageParam: (lastPage) => {
+        return lastPage.totalCount === lastPage.reservations.length
+          ? undefined
+          : lastPage.cursorId;
+      },
+      initialPageParam: undefined,
+    });
 
-  return myReservationList;
+  const myReservationList = useMemo(() => {
+    if (data) {
+      return data.pages.flatMap((page) => page.reservations);
+    }
+  }, [data]);
+
+  return {
+    myReservationList,
+    fetchNextPage,
+    hasNextPage,
+    isLoading,
+    isFetchingNextPage,
+  };
 };

--- a/hooks/useReservationList.ts
+++ b/hooks/useReservationList.ts
@@ -3,21 +3,23 @@ import { apiMyReservationList } from '@/pages/api/myReservations/apiMyReservatio
 import { useUserData } from './useUserData';
 import { MyReservationListResponse } from '@/pages/api/myReservations/apiMyReservations.types';
 import { useMemo } from 'react';
+import { statusType } from '@/components/ReservationFilter/myReservationTypes.types';
 
 const INITIAL_SIZE = 4;
 const REFETCH_SIZE = 1;
 
-export const useReservationList = () => {
+export const useReservationList = (filterOption: statusType | undefined) => {
   const userData = useUserData();
 
   const { data, fetchNextPage, hasNextPage, isLoading, isFetchingNextPage } =
     useInfiniteQuery<MyReservationListResponse>({
-      queryKey: ['myReservationList', userData.id],
+      queryKey: ['myReservationList', userData.id, filterOption],
       queryFn: ({ pageParam = undefined }) => {
         const size = pageParam === undefined ? INITIAL_SIZE : REFETCH_SIZE;
         return apiMyReservationList({
           size: size,
           cursorId: pageParam as number | undefined,
+          status: filterOption ?? undefined,
         });
       },
       enabled: !!userData.id,

--- a/hooks/useUserData.ts
+++ b/hooks/useUserData.ts
@@ -10,7 +10,7 @@ export const useUserData = () => {
   const [userData, setUserData] = useRecoilState(userState);
   const { isLoggedIn } = useLoginState();
 
-  const { data: userResponseData, isError } = useQuery({
+  const { data: userResponseData } = useQuery({
     queryKey: ['user', userId],
     queryFn: apiMyInfo,
     enabled: !!isLoggedIn,

--- a/hooks/useUserData.ts
+++ b/hooks/useUserData.ts
@@ -23,7 +23,6 @@ export const useUserData = () => {
   }, [userResponseData]);
 
   useEffect(() => {
-    console.log('hi');
     const userId = localStorage.getItem('userId') || '';
     setUserId(userId);
   }, []);

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-calendar": "^5.0.0",
         "react-dom": "^18",
         "react-hook-form": "^7.52.1",
+        "react-intersection-observer": "^9.13.0",
         "react-slick": "^0.30.2",
         "recoil": "^0.7.7",
         "slick-carousel": "^1.8.1",
@@ -4271,6 +4272,20 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.13.0.tgz",
+      "integrity": "sha512-y0UvBfjDiXqC8h0EWccyaj4dVBWMxgEx0t5RGNzQsvkfvZwugnKwxpu70StY4ivzYuMajavwUDjH4LJyIki9Lw==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
     "react-calendar": "^5.0.0",
     "react-dom": "^18",
     "react-hook-form": "^7.52.1",
-    "recoil": "^0.7.7",
-    "tailwind-scrollbar-hide": "^1.1.7",
+    "react-intersection-observer": "^9.13.0",
     "react-slick": "^0.30.2",
-    "slick-carousel": "^1.8.1"
+    "recoil": "^0.7.7",
+    "slick-carousel": "^1.8.1",
+    "tailwind-scrollbar-hide": "^1.1.7"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/pages/reservation.tsx
+++ b/pages/reservation.tsx
@@ -11,13 +11,13 @@ import {
 import { useInView } from 'react-intersection-observer';
 
 export default function MyReservationPage() {
-  const [filterOption, setFilterOption] = useState<statusType>();
+  const [filterOption, setFilterOption] = useState<statusType | undefined>();
   const [reservationListByFilter, setReservationListByFilter] = useState<
     MyReservationProps[]
   >([]);
   const { ref, inView } = useInView();
   const { fetchNextPage, myReservationList, hasNextPage } =
-    useReservationList();
+    useReservationList(filterOption);
 
   useEffect(() => {
     if (inView && hasNextPage) {
@@ -27,17 +27,9 @@ export default function MyReservationPage() {
 
   useEffect(() => {
     if (myReservationList) {
-      const reservationList = myReservationList;
-      if (filterOption) {
-        const filteredData = reservationList.filter(
-          (card) => card.status === filterOption
-        );
-        setReservationListByFilter(filteredData);
-      } else {
-        setReservationListByFilter(reservationList);
-      }
+      setReservationListByFilter(myReservationList);
     }
-  }, [myReservationList, filterOption]);
+  }, [myReservationList]);
 
   return (
     <div className="flex justify-center w-full mt-[72px] gap-[24px] t:mt-[24px] t:gap-[16px]">

--- a/pages/reservation.tsx
+++ b/pages/reservation.tsx
@@ -23,10 +23,7 @@ export default function MyReservationPage() {
     if (inView && hasNextPage) {
       fetchNextPage();
     }
-    console.log(myReservationList);
   }, [inView]);
-
-  console.log(hasNextPage);
 
   useEffect(() => {
     if (myReservationList) {

--- a/pages/reservation.tsx
+++ b/pages/reservation.tsx
@@ -8,17 +8,29 @@ import {
   MyReservationProps,
   statusType,
 } from '@/components/ReservationFilter/myReservationTypes.types';
+import { useInView } from 'react-intersection-observer';
 
 export default function MyReservationPage() {
   const [filterOption, setFilterOption] = useState<statusType>();
   const [reservationListByFilter, setReservationListByFilter] = useState<
     MyReservationProps[]
   >([]);
-  const myReservationList = useReservationList();
+  const { ref, inView } = useInView();
+  const { fetchNextPage, myReservationList, hasNextPage } =
+    useReservationList();
+
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      fetchNextPage();
+    }
+    console.log(myReservationList);
+  }, [inView]);
+
+  console.log(hasNextPage);
 
   useEffect(() => {
     if (myReservationList) {
-      const reservationList = myReservationList.reservations;
+      const reservationList = myReservationList;
       if (filterOption) {
         const filteredData = reservationList.filter(
           (card) => card.status === filterOption
@@ -43,9 +55,9 @@ export default function MyReservationPage() {
             />
           )}
         </div>
-        <div className="flex flex-col animate-slideDown overflow-auto scrollbar-hide h-[calc(100vh-380px)] gap-[24px] pr-[10px]">
-          {reservationListByFilter.length > 0 ? (
-            reservationListByFilter.map(
+        {reservationListByFilter.length > 0 ? (
+          <div className="flex flex-col animate-slideDown gap-[24px] overflow-auto scrollbar-hide h-[calc(100vh-220px)] pr-[10px]">
+            {reservationListByFilter.map(
               (reservationData: MyReservationProps) => {
                 return (
                   <div key={reservationData.id}>
@@ -53,23 +65,28 @@ export default function MyReservationPage() {
                   </div>
                 );
               }
-            )
-          ) : (
-            <div className="flex flex-col h-[500px] items-center justify-center">
-              <div>
-                <Image
-                  src="/icon/empty_reservation.svg"
-                  alt="등록된 체험이 없어요"
-                  width={240}
-                  height={240}
-                />
+            )}
+            {hasNextPage && (
+              <div className="text-[35px] font-bold text-center" ref={ref}>
+                ...
               </div>
-              <span className="text-var-gray7 text-[24px]">
-                등록된 체험이 없어요
-              </span>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col h-[500px] items-center justify-center">
+            <div>
+              <Image
+                src="/icon/empty_reservation.svg"
+                alt="등록된 체험이 없어요"
+                width={240}
+                height={240}
+              />
             </div>
-          )}
-        </div>
+            <span className="text-var-gray7 text-[24px]">
+              등록된 체험이 없어요
+            </span>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
### 🔎 작업 내용
 - [x] 예약 내역 페이지 무한스크롤 useInfiniteQuery와 커서페이지네이션 활용하여 구현하였습니다.
 - [x] 상태 정렬 부분 로직으로 구현했던 부분 api로 수정하였습니다.

### :warning: 이슈
 - x

### :loudspeaker: 전달사항
 - 반응형,,, 아직입니다아,,,
 - react-intersection-observer 라이브러리 추가하였습니다
 `npm install react-intersection-observer --save`
