### PR TITLE
fix: 모바일 알림 드롭다운 무한스크롤 버그 수정 및 스타일 수정

### DIFF
--- a/components/Layout/NavigationBar.tsx
+++ b/components/Layout/NavigationBar.tsx
@@ -73,7 +73,7 @@ export default function NavigationBar() {
                 <div className="relative">
                   <Image src={notificationIcon} alt="알림 아이콘" />
                   {data?.totalCount !== undefined && data?.totalCount > 0 && (
-                    <span className="flex justify-center absolute -top-2 -right-2 bg-red-500 w-[15px] h-[15px] text-white text-xs rounded-full px-2">
+                    <span className="flex justify-center items-center absolute -top-2 -right-2 bg-red-500 w-[15px] h-[15px] text-white text-xs rounded-full px-2">
                       {data.totalCount}
                     </span>
                   )}

--- a/components/NavigationDropdown/NotificationDropdown.tsx
+++ b/components/NavigationDropdown/NotificationDropdown.tsx
@@ -59,17 +59,17 @@ export default function NotificationDropdown({
   }, []);
 
   return (
-    <div className="z-50 px-[20px] pt-[17px] pb-[24px] absolute top-[60px] t:right-[100px] w-[368px] h-[340px] animate-slideDown flex-col justify-center overflow-y-auto scrollbar-hide rounded-[5px] m:fixed m:inset-0 m:rounded-none m:w-full m:h-full bg-var-green1 dark:bg-var-dark2 m:overflow-y-hidden ">
-      <div className="flex text-[20px] font-bold mb-[25px] justify-between ">
+    <div className="z-50 px-[20px] py-[17px] absolute top-[60px] t:right-[100px] w-[368px] h-[360px] animate-slideDown flex-col justify-center overflow-y-auto scrollbar-hide rounded-[5px] m:fixed m:inset-0 m:rounded-none m:w-full m:h-full bg-var-green1 dark:bg-var-dark2 border-var-dark3 border border-solid">
+      <div className="flex text-[20px] font-bold mb-[10px] justify-between ">
         알림 {data ? `${data.totalCount}` : '0'}개
         <CloseButton onClick={onClick} />
       </div>
       {notificationList && data?.totalCount ? (
-        <div className="flex flex-col items-center gap-[15px]">
+        <div className="flex flex-col items-center gap-[17px]">
           {notificationList.map((notification) => (
             <div
               key={notification.id}
-              className="flex-col  items-center px-[12px] py-[16px] justify-between rounded-[5px] border-b w-[328px] min-h-[120px] m:w-[335px] bg-white border-gray-200 dark:bg-var-dark4 "
+              className="flex-col  items-center px-[12px] pt-[10px] pb-[7px] justify-between rounded-[5px] border-b w-[328px] min-h-[120px] m:w-[335px] bg-white border-gray-200 dark:bg-var-dark4 "
             >
               <div className="flex justify-between">
                 <StatusIndicator


### PR DESCRIPTION
### 🔎 작업 내용
 - [x] 설정오류로 모바일에서 무한 스크롤 안되는 현상 수정했습니다
 - [x] 다크모드시에 드롭다운과 예약내역 구분이 모호해 border 추가했습니다
 - [x] 그 외 알림 드롭다운 스타일 수정 했습니다. 
<전> 
![image](https://github.com/user-attachments/assets/e3979d63-baff-420f-9656-519a1f2bd78c)
<후>
![image](https://github.com/user-attachments/assets/5ed9bd10-f0af-4c9f-9e22-77b543254dd8)


### :warning: 이슈
 - 해결하지 못한 이슈가 있으면 적어주세요

### :loudspeaker: 전달사항
 - 추가한 라이브러리나 특이 사항이 있으면 적어주세요
