### PR TITLE
feat: 알림 카운트 위치조정 및 알림 클릭시 예약 내역페이지 이동

### DIFF
--- a/components/Layout/NavigationBar.tsx
+++ b/components/Layout/NavigationBar.tsx
@@ -84,7 +84,7 @@ export default function NavigationBar() {
                   <Image src={notificationIcon} alt="알림 아이콘" />
                   {data?.totalCount !== undefined && data?.totalCount > 0 && (
                     <span className="absolute top-[-7px] right-[-7px] bg-red-500 w-[15px] h-[15px] text-white text-[12px] rounded-full">
-                      <p className="pr-[1.5px] translate-y-[-10%]">
+                      <p className="pr-[1.5px] translate-y-[-10%] translate-x-[5%]">
                         {data.totalCount}
                       </p>
                     </span>

--- a/components/Layout/NavigationBar.tsx
+++ b/components/Layout/NavigationBar.tsx
@@ -83,8 +83,8 @@ export default function NavigationBar() {
                 <div className="relative">
                   <Image src={notificationIcon} alt="알림 아이콘" />
                   {data?.totalCount !== undefined && data?.totalCount > 0 && (
-                    <span className="absolute top-[-7px] right-[-7px] bg-red-500 w-[15px] h-[15px] text-white text-[12px] rounded-full">
-                      <p className="pr-[1.5px] translate-y-[-10%] translate-x-[5%]">
+                    <span className="absolute top-[-7px] right-[-7px] flex items-center justify-center bg-red-500 w-[15px] h-[15px] text-white text-[12px] rounded-full">
+                      <p className="translate-y-[-4%] translate-x-[-10%]">
                         {data.totalCount}
                       </p>
                     </span>

--- a/components/NavigationDropdown/NotificationDropdown.tsx
+++ b/components/NavigationDropdown/NotificationDropdown.tsx
@@ -6,6 +6,7 @@ import useDeleteNotification from '@/hooks/useDeleteNotification';
 import { useInView } from 'react-intersection-observer';
 import useGetNotificationList from '@/hooks/useGetNotificationList';
 import formatTimeAgo from '@/utils/formatTimeAgo';
+import Link from 'next/link';
 
 export default function NotificationDropdown({
   data,
@@ -84,12 +85,14 @@ export default function NotificationDropdown({
                   <CloseButton onClick={() => handleDelete(notification.id)} />
                 </div>
               </div>
-              <div className="w-[298px] min-h-[44px] mb-[4px]">
-                {ContentWithHighlights(notification.content)}
-              </div>
-              <div className="text-[12px]">
-                {formatTimeAgo(notification.updatedAt)}
-              </div>
+              <Link href="/reservation">
+                <div className="w-[298px] min-h-[44px] mb-[4px]">
+                  {ContentWithHighlights(notification.content)}
+                </div>
+                <div className="text-[12px]">
+                  {formatTimeAgo(notification.updatedAt)}
+                </div>
+              </Link>
             </div>
           ))}
           {hasNextPage && <div ref={ref} />}


### PR DESCRIPTION
### 🔎 작업 내용
 - [x] 알림 내역을 누르면 예약내역 페이지로 이동
 - [x] 알림 아이콘 우측 상단 알림 카운트 위치 조정


### :warning: 이슈
 - 제 화면상 은지님이 공유해주셨던 글자 중앙 이탈 현상과는 달라서, 특정 환경마다 다를 수도 있기 때문에 적용 후에도 해결 되지 않는다면, 좀 더 수정해보겠습니다.

### :loudspeaker: 전달사항
 - 
